### PR TITLE
fix: honor status code in WriteJSON

### DIFF
--- a/api/cmd/pkgs/utils/utils.go
+++ b/api/cmd/pkgs/utils/utils.go
@@ -8,7 +8,7 @@ import (
 
 func WriteJSON(w http.ResponseWriter, statusCode int, v any) error {
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(statusCode)
 	return json.NewEncoder(w).Encode(v)
 }
 


### PR DESCRIPTION
## Summary
- respect provided status code when sending JSON responses
- audit WriteJSON usage to confirm handlers pass the correct HTTP status codes

## Testing
- `go test ./...` *(fails: undefined base64urlSha256JWK, cnfJKTFromContext)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a829038544832a9f926d92f2ea4941