### PR TITLE
allow future expiration dates in key dialog

### DIFF
--- a/app/admin/keys/createNewKeyDialog.tsx
+++ b/app/admin/keys/createNewKeyDialog.tsx
@@ -203,6 +203,8 @@ export default function CreateNewKeyDialog() {
                                                                     mode="single"
                                                                     selected={date}
                                                                     captionLayout="dropdown"
+                                                                    fromYear={new Date().getFullYear()}
+                                                                    toYear={2099}
                                                                     disabled={(d) => d < new Date(new Date().setHours(0, 0, 0, 0))}
                                                                     onSelect={(d) => {
                                                                         setOpenCalendar(false)


### PR DESCRIPTION
## Summary
- allow selecting expiration dates beyond the current year in CreateNewKey dialog

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find name 'Deno' and other type errors in supabase functions)*

------
https://chatgpt.com/codex/tasks/task_e_68c6973c0884832aa28518bb19f417fe