### PR TITLE
Fix release detection operator mapping

### DIFF
--- a/src/modules/apps/detail/releases/app-release-sheet.tsx
+++ b/src/modules/apps/detail/releases/app-release-sheet.tsx
@@ -256,21 +256,26 @@ const mapReleaseToFormValues = (release: any) => {
   const uninstallGroups = [...staticUninstall, ...dynamicUninstall];
 
   const detections = dRules.map((d: any) => {
-    const config = d.config;
+    const config = d.config || {};
+    const operator =
+      config.operator || config.fileType || config.registryType || "exists";
+    const value =
+      config.value || config.fileTypeValue || config.registryTypeValue || "";
+
     if (d.type === "file") {
       return {
         type: "file" as const,
         path: config.path || "",
-        fileType: (config.fileType || "exists") as any,
-        fileTypeValue: config.fileTypeValue || "",
+        fileType: operator as any,
+        fileTypeValue: value,
       };
     } else {
       return {
         type: "registry" as const,
         path: config.path || config.registryKey || "",
         registryKey: config.registryKey || config.path || "",
-        registryType: (config.registryType || "exists") as any,
-        registryTypeValue: config.registryTypeValue || "",
+        registryType: operator as any,
+        registryTypeValue: value,
       };
     }
   });


### PR DESCRIPTION
### Motivation
- Preserve the saved detection operator and value when loading an existing release into the create/edit form so detection methods like `version_higher` are not overwritten back to `exists`.

### Description
- Change in `src/modules/apps/detail/releases/app-release-sheet.tsx`: `mapReleaseToFormValues` now prefers `config.operator` and `config.value` and falls back to legacy `fileType`/`registryType` and `fileTypeValue`/`registryTypeValue` when mapping detection rules into form values.

### Testing
- `pnpm exec tsc --noEmit` passed.
- `pnpm lint` was run but failed due to an existing unrelated lint error in `convex/migrations.ts` (`@convex-dev/explicit-table-ids`) and other existing warnings outside this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d1b5d15d4832aab9ddbe2b6241dc2)