### PR TITLE
Fix app install state release tracking

### DIFF
--- a/convex/apps.ts
+++ b/convex/apps.ts
@@ -494,13 +494,15 @@ export const updateInstallState = internalMutation({
             .first();
 
         const now = Date.now();
+        const releaseChanged = existing?.release_id !== normalizedReleaseId;
         const nextInstalledAt =
             status === "INSTALLED"
-                ? installedAt ?? existing?.installed_at ?? now
-                : installedAt ?? existing?.installed_at;
+                ? installedAt ?? (releaseChanged ? now : existing?.installed_at) ?? now
+                : installedAt ?? (releaseChanged ? undefined : existing?.installed_at);
 
         const updatePayload = {
             status,
+            release_id: normalizedReleaseId,
             status_updated_at: now,
             last_seen_at: lastSeenAt ?? now,
             ...(nextInstalledAt !== undefined
@@ -513,7 +515,6 @@ export const updateInstallState = internalMutation({
         } else {
             await ctx.db.insert("computer_apps_installs", {
                 computer_id: normalizedComputerId,
-                release_id: normalizedReleaseId,
                 app_id: appId,
                 ...updatePayload,
             });


### PR DESCRIPTION
### Motivation
- Clients reported installs against the wrong release because existing `computer_apps_installs` rows were patched without updating the `release_id`, so the UI continued to show the previous release.
- When a new release was reported without an explicit `installed_at`, the previous release's `installed_at` could be incorrectly reused.

### Description
- Update the `updateInstallState` internal mutation in `convex/apps.ts` to include the reported `release_id` in the `updatePayload` so existing rows are moved to the correct release.
- Detect when the reported release changes and adjust computation of `installed_at` so a newly reported install does not inherit the old release's timestamp.
- Ensure `insert` and `patch` use a consistent `updatePayload` and avoid duplicate `release_id` in the insert call.

### Testing
- Ran TypeScript check with `pnpm exec tsc --noEmit`, which succeeded.
- Ran linter with `pnpm lint`, which reported a pre-existing error in `convex/migrations.ts` and multiple warnings (the lint run failed due to that unrelated error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f52468e14832ab70f5283f99d9e9a)