### PR TITLE
Add option to copy settings from an existing release when creating a release

### DIFF
--- a/src/app/(app)/apps/[id]/page.tsx
+++ b/src/app/(app)/apps/[id]/page.tsx
@@ -301,6 +301,7 @@ export default function AppDetailPage() {
               <AppReleaseSheet
                 appId={appId}
                 isAutoUpdate={app.auto_update}
+                copyableReleases={releases ?? []}
                 open={showCreateReleaseSheet}
                 onOpenChange={setShowCreateReleaseSheet}
               />

--- a/src/modules/apps/detail/releases/app-release-sheet.tsx
+++ b/src/modules/apps/detail/releases/app-release-sheet.tsx
@@ -682,7 +682,30 @@ export function AppReleaseSheet({
       return;
     }
 
-    const values = mapReleaseToFormValues(sourceRelease);
+    const normalizedSourceRelease = {
+      ...sourceRelease,
+      detections: sourceRelease.detections?.map((detection) => ({
+        ...detection,
+        config: {
+          ...detection.config,
+          ...(detection.type === "file"
+            ? {
+              fileType:
+                detection.config.fileType ?? detection.config.operator,
+              fileTypeValue:
+                detection.config.fileTypeValue ?? detection.config.value,
+            }
+            : {
+              registryType:
+                detection.config.registryType ?? detection.config.operator,
+              registryTypeValue:
+                detection.config.registryTypeValue ?? detection.config.value,
+            }),
+        },
+      })),
+    };
+
+    const values = mapReleaseToFormValues(normalizedSourceRelease);
     if (!values) {
       return;
     }

--- a/src/modules/apps/detail/releases/app-release-sheet.tsx
+++ b/src/modules/apps/detail/releases/app-release-sheet.tsx
@@ -742,13 +742,12 @@ export function AppReleaseSheet({
                 <div className="h-full overflow-y-auto px-6 py-6 pb-12">
                   <TabsContent value="details" className="space-y-4 m-0">
                     {!isEdit && copyableReleases.length > 0 && (
-                      <div className="rounded-lg border bg-muted/30 p-3">
-                        <div className="mb-3 flex items-center gap-2 text-sm font-medium">
-                          <Copy className="h-4 w-4" />
-                          Copy settings from another release
+                      <div className="flex items-center gap-3">
+                        <div className="flex shrink-0 items-center gap-2 text-sm font-medium">
+                          Copy settings from
                         </div>
                         <Select onValueChange={handleCopyReleaseSettings}>
-                          <SelectTrigger>
+                          <SelectTrigger className="min-w-0 flex-1">
                             <SelectValue placeholder="Select source release" />
                           </SelectTrigger>
                           <SelectContent>
@@ -763,11 +762,6 @@ export function AppReleaseSheet({
                             ))}
                           </SelectContent>
                         </Select>
-                        <p className="mt-2 text-xs text-muted-foreground">
-                          Copies scripts, installer settings, requirements,
-                          detection rules, and assignments. The new release
-                          version stays empty.
-                        </p>
                       </div>
                     )}
 

--- a/src/modules/apps/detail/releases/app-release-sheet.tsx
+++ b/src/modules/apps/detail/releases/app-release-sheet.tsx
@@ -39,7 +39,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { X, Plus, Trash2, Pencil } from "lucide-react";
+import { Copy, X, Plus, Trash2, Pencil } from "lucide-react";
 import {
   detectionItemSchema,
   storedFileReferenceSchema,
@@ -107,55 +107,69 @@ const createFormSchema = (isAutoUpdate: boolean) =>
 
 type FormValues = z.infer<ReturnType<typeof createFormSchema>>;
 
+export interface ReleaseFormRelease {
+  id: string;
+  version: string;
+  installer_type: string;
+  uninstall_previous?: boolean;
+  disabled_at?: string | number | null;
+  computer_group_releases?: {
+    assign_type: string;
+    action: string;
+    computer_groups: {
+      _id: string;
+      display_name: string;
+    } | null;
+  }[];
+  dynamic_group_releases?: {
+    assign_type: string;
+    action: string;
+    dynamic_computer_groups: {
+      _id: string;
+      display_name: string;
+    } | null;
+  }[];
+  staticAssignments?: unknown[];
+  dynamicAssignments?: unknown[];
+  detection_rules?: {
+    type: string;
+    config: any;
+  }[];
+  detections?: any[];
+  release_requirements?: {
+    timeout_seconds: number;
+    run_as_system: boolean;
+    storage_id?: string;
+    byte_size?: number;
+    hash: string;
+  }[];
+  win32_releases?: {
+    install_script: string;
+    uninstall_script: string;
+    install_binary_storage_id?: string;
+    install_binary_size?: number;
+    hash: string;
+  }[];
+  winget_releases?: {
+    winget_id: string;
+  }[];
+  release_scripts?: {
+    phase: "pre" | "post";
+    engine: "cmd" | "powershell";
+    timeout_seconds: number;
+    run_as_system: boolean;
+    script_name: string;
+    storage_id?: string;
+    byte_size?: number;
+    hash: string;
+  }[];
+}
+
 interface EditReleaseSheetProps {
   appId: string;
   isAutoUpdate?: boolean;
-  release?: {
-    id: string;
-    version: string;
-    installer_type: string;
-    uninstall_previous?: boolean;
-    disabled_at?: string | number | null;
-    computer_group_releases?: {
-      assign_type: string;
-      action: string;
-      computer_groups: {
-        _id: string;
-        display_name: string;
-      } | null;
-    }[];
-    detection_rules?: {
-      type: string;
-      config: any;
-    }[];
-    release_requirements?: {
-      timeout_seconds: number;
-      run_as_system: boolean;
-      storage_id?: string;
-      byte_size?: number;
-      hash: string;
-    }[];
-    win32_releases?: {
-      install_script: string;
-      uninstall_script: string;
-      install_binary_storage_id?: string;
-      install_binary_size?: number;
-      hash: string;
-    }[];
-    winget_releases?: {
-      winget_id: string;
-    }[];
-    release_scripts?: {
-      phase: "pre" | "post";
-      engine: "cmd" | "powershell";
-      timeout_seconds: number;
-      run_as_system: boolean;
-      script_name: string;
-      storage_id?: string;
-      byte_size?: number;
-      hash: string;
-    }[];
-  } | null;
+  release?: ReleaseFormRelease | null;
+  copyableReleases?: ReleaseFormRelease[];
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
@@ -373,6 +387,7 @@ export function AppReleaseSheet({
   appId,
   isAutoUpdate = false,
   release,
+  copyableReleases = [],
   open,
   onOpenChange,
 }: AppReleaseSheetProps) {
@@ -658,6 +673,30 @@ export function AppReleaseSheet({
     setIsDetectionSheetOpen(true);
   };
 
+  const handleCopyReleaseSettings = (sourceReleaseId: string) => {
+    const sourceRelease = copyableReleases.find(
+      (candidate) => candidate.id === sourceReleaseId,
+    );
+
+    if (!sourceRelease) {
+      return;
+    }
+
+    const values = mapReleaseToFormValues(sourceRelease);
+    if (!values) {
+      return;
+    }
+
+    form.reset({
+      ...values,
+      version: form.getValues("version") || "",
+      disabled: false,
+    });
+    toast.success(
+      `Settings copied from release ${sourceRelease.version || "latest"}.`,
+    );
+  };
+
   const isEdit = !!release;
 
   return (
@@ -702,6 +741,36 @@ export function AppReleaseSheet({
 
                 <div className="h-full overflow-y-auto px-6 py-6 pb-12">
                   <TabsContent value="details" className="space-y-4 m-0">
+                    {!isEdit && copyableReleases.length > 0 && (
+                      <div className="rounded-lg border bg-muted/30 p-3">
+                        <div className="mb-3 flex items-center gap-2 text-sm font-medium">
+                          <Copy className="h-4 w-4" />
+                          Copy settings from another release
+                        </div>
+                        <Select onValueChange={handleCopyReleaseSettings}>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select source release" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {copyableReleases.map((copyRelease) => (
+                              <SelectItem
+                                key={copyRelease.id}
+                                value={copyRelease.id}
+                              >
+                                {copyRelease.version || "latest"} ·{" "}
+                                {copyRelease.installer_type}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <p className="mt-2 text-xs text-muted-foreground">
+                          Copies scripts, installer settings, requirements,
+                          detection rules, and assignments. The new release
+                          version stays empty.
+                        </p>
+                      </div>
+                    )}
+
                     <FormField
                       control={form.control}
                       name="type"


### PR DESCRIPTION
### Motivation
- Speed up creating new releases by allowing users to copy installer/scripts/requirements/detections/assignments from an existing release to avoid repetitive re-entry.
- Keep the new release `version` empty and enabled while copying configuration from a source release to prevent accidental overwrites.

### Description
- Added an exported `ReleaseFormRelease` type and a `copyableReleases?: ReleaseFormRelease[]` prop to the `AppReleaseSheet` component to accept existing releases as copy sources (`src/modules/apps/detail/releases/app-release-sheet.tsx`).
- Added a UI selector in the create-release sheet labeled "Copy settings from another release" that appears only when creating (not editing) and when `copyableReleases` is non-empty; choosing a source calls `mapReleaseToFormValues` and resets the form with the copied settings while preserving the new release `version` and `disabled` state.
- Passed the current app `releases` into the create-release sheet on the app detail page via `copyableReleases={releases ?? []}` (`src/app/(app)/apps/[id]/page.tsx`).

### Testing
- Ran TypeScript compilation: `pnpm exec tsc --noEmit` (succeeded).
- Ran targeted ESLint: `pnpm exec eslint src/modules/apps/detail/releases/app-release-sheet.tsx src/app/'(app)'/apps/'[id]'/page.tsx src/modules/apps/detail/releases/app-releases-table.tsx` (succeeded).
- Ran full lint: `pnpm lint` (failed due to an existing unrelated Convex lint error in `convex/migrations.ts`; this is a pre-existing issue and not caused by these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f56a54eac832a83cca3abc7e8b23e)